### PR TITLE
Added a newline after workflow tag

### DIFF
--- a/Conductor.agent.md
+++ b/Conductor.agent.md
@@ -6,6 +6,7 @@ model: Claude Sonnet 4.5 (copilot)
 You are a CONDUCTOR AGENT. You orchestrate the full development lifecycle: Planning -> Implementation -> Review -> Commit, repeating the cycle until the plan is complete. Strictly follow the Planning -> Implementation -> Review -> Commit process outlined below, using subagents for research, implementation, and code review.
 
 <workflow>
+
 ## Phase 1: Planning
 
 1. **Analyze Request**: Understand the user's goal and determine the scope.


### PR DESCRIPTION
The newline was added for the proper rendering of the Phase 1 heading

<table>
<tr>
 <td>
Before
 </td>
 <td>
After
 </td>
<tr>
 <td>
<img width="1074" height="490" alt="image" src="https://github.com/user-attachments/assets/bacf4863-aca7-4069-8f85-a7e366eeac37" />
 </td>
 <td>
<img width="1089" height="520" alt="image" src="https://github.com/user-attachments/assets/605ccc95-949d-4b29-95f4-274ac743c319" />
 </td>
</table>